### PR TITLE
fix(security): upgrade multer to 2.0.1 to patch DoS vulnerability

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "mailtrap": "^3.4.0",
     "mongodb": "^6.12.0",
     "mongoose": "^8.10.1",
-    "multer": "^1.4.5-lts.1",
+    "multer": "^2.0.1",
     "multer-storage-cloudinary": "^4.0.0",
     "passport": "^0.7.0",
     "passport-google-oauth20": "^2.0.0",


### PR DESCRIPTION
- Updated multer from ^1.4.5-lts.1 to ^2.0.1
- Addresses CVE allowing DoS via empty field names during file uploads
- Refer: expressjs/multer#1256